### PR TITLE
fix: compare with urns on rarest item

### DIFF
--- a/src/avatar/index.ts
+++ b/src/avatar/index.ts
@@ -118,12 +118,13 @@ let rarestEquippedItem: rarityLevel = 0
 	if (!profile || !inventory) return rarityLevel.none
 
 	if (equiped) {
-	  for (const item of profile.metadata.avatars[0]?.avatar.wearables) {
-		for (let invItem of inventory) {
-		  if (item == invItem.id && invItem.rarity) {
-			updateRarity(invItem.rarity)
-		  }
-		}
+    const equipedAsUrn = profile.metadata.avatars[0]?.avatar?.wearables?.map(mapToUrn)
+	  for (const item of equipedAsUrn) {
+      for (let invItem of inventory) {
+        if (item === invItem.id && invItem.rarity) {
+          updateRarity(invItem.rarity)
+        }
+      }
 	  }
 	} else {
 	  for (let invItem of inventory) {

--- a/src/avatar/index.ts
+++ b/src/avatar/index.ts
@@ -119,7 +119,7 @@ let rarestEquippedItem: rarityLevel = 0
 
 	if (equiped) {
     const equipedAsUrn = profile.metadata.avatars[0]?.avatar?.wearables?.map(mapToUrn)
-	  for (const item of equipedAsUrn) {
+    for (const item of equipedAsUrn) {
       for (let invItem of inventory) {
         if (item === invItem.id && invItem.rarity) {
           updateRarity(invItem.rarity)


### PR DESCRIPTION
When calculating the rarest item, we had forgotten to convert the equipped wearables to urn. So when the inventory was compared with the equipped items, no match would be found