### PR TITLE
fix: make lib work in preview mode

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,9 +1,9 @@
-import { getCurrentRealm } from "@decentraland/EnvironmentAPI"
+import { getCurrentRealm, isPreviewMode } from "@decentraland/EnvironmentAPI"
 import { Representation, Type, Wearable } from "../wearable/types"
 
-export function getCatalystUrl(): Promise<string> {
-  return getCurrentRealm()
-    .then((r: any) => r.domain != 'http://127.0.0.1:8000' &&  r.domain != 'http://192.168.0.18:8000'  ? r.domain : 'https://peer.decentraland.org')
+export async function getCatalystUrl(): Promise<string> {
+  const inPreview = await isPreviewMode()
+  return inPreview ? 'https://peer.decentraland.org' : getCurrentRealm().then(({ domain }) => domain)
 }
 
 export function mapV2WearableIntoV1(catalystUrl: string, v2Wearable: any): Wearable {


### PR DESCRIPTION
Previously, when we tried to find out the catalyst url, we tried to detect if we were in preview mode by comparing the catalyst url to some local IPs. The problem is that the used IP can be different from the ones that were checked. 

So instead, we are using the `isPreviewMode` function from the `EnvironmentAPI`. 